### PR TITLE
Improve the CMake for the tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,23 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(TRIGDX_USE_MKL "Enable Intel MKL backend" OFF)
 option(TRIGDX_USE_GPU "Enable GPU backend" OFF)
 option(TRIGDX_USE_XSIMD "Enable XSIMD backend" OFF)
+option(TRIGDX_BUILD_TESTS "Build tests" ON)
+option(TRIGDX_BUILD_BENCHMARKS "Build tests" ON)
+
+if(TRIGDX_BUILD_TESTS OR TRIGDX_BUILD_BENCHMARKS)
+  include(FetchContent)
+endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
 add_subdirectory(src)
-add_subdirectory(tests)
-add_subdirectory(benchmarks)
+
+if(TRIGDX_BUILD_TESTS)
+  include(CTest)
+  enable_testing()
+  add_subdirectory(tests)
+endif()
+
+if(TRIGDX_BUILD_BENCHMARKS)
+  add_subdirectory(benchmarks)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(FetchContent)
-
 FetchContent_Declare(
   catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
@@ -9,30 +7,28 @@ FetchContent_MakeAvailable(catch2)
 # Lookup backend test
 add_executable(test_lookup test_lookup.cpp)
 target_link_libraries(test_lookup PRIVATE trigdx Catch2::Catch2WithMain)
+add_test(NAME test_lookup COMMAND test_lookup)
 
 # LookupAVX backend test
 add_executable(test_lookup_avx test_lookup_avx.cpp)
 target_link_libraries(test_lookup_avx PRIVATE trigdx Catch2::Catch2WithMain)
+add_test(NAME test_lookup_avx COMMAND test_lookup_avx)
 
 # MKL backend test
 if(TRIGDX_USE_MKL)
   add_executable(test_mkl test_mkl.cpp)
   target_link_libraries(test_mkl PRIVATE trigdx Catch2::Catch2WithMain)
-endif()
-
-include(CTest)
-add_test(NAME test_lookup COMMAND test_lookup)
-
-if(TRIGDX_USE_MKL)
   add_test(NAME test_mkl COMMAND test_mkl)
 endif()
 
+# GPU backend test
 if(TRIGDX_USE_GPU)
   add_executable(test_gpu test_gpu.cpp)
   target_link_libraries(test_gpu PRIVATE trigdx Catch2::Catch2WithMain)
   add_test(NAME test_gpu COMMAND test_gpu)
 endif()
 
+# XSIMD backend test
 if(TRIGDX_USE_XSIMD)
   add_executable(test_lookup_xsimd test_lookup_xsimd.cpp)
   target_link_libraries(test_lookup_xsimd PRIVATE trigdx Catch2::Catch2WithMain)


### PR DESCRIPTION
The tests were not properly registered by CTest, this is now fixed. This MR also contains some minor cleanup of related CMake code.