### PR TITLE
Fix issue when building with TRIGDX_USE_GPU=1

### DIFF
--- a/cmake/trigdx_config.hpp.in
+++ b/cmake/trigdx_config.hpp.in
@@ -1,5 +1,5 @@
 #pragma once
 
-#define TRIGDX_USE_MKL @TRIGDX_USE_MKL@
-#define TRIGDX_USE_GPU @TRIGDX_USE_GPU@
-#define TRIGDX_USE_XSIMD @TRIGDX_USE_XSIMD@
+#cmakedefine TRIGDX_USE_MKL
+#cmakedefine TRIGDX_USE_GPU
+#cmakedefine TRIGDX_USE_XSIMD

--- a/include/trigdx/trigdx.hpp
+++ b/include/trigdx/trigdx.hpp
@@ -6,14 +6,14 @@
 #include <trigdx/lookup.hpp>
 #include <trigdx/lookup_avx.hpp>
 
-#if TRIGDX_USE_MKL
+#if defined(TRIGDX_USE_MKL)
 #include <trigdx/mkl.hpp>
 #endif
 
-#if TRIGDX_USE_GPU
+#if defined(TRIGDX_USE_GPU)
 #include <trigdx/gpu.hpp>
 #endif
 
-#if TRIGDX_USE_XSIMD
+#if defined(TRIGDX_USE_XSIMD)
 #include <trigdx/lookup_xsimd.hpp>
 #endif


### PR DESCRIPTION
https://github.com/astron-rd/TrigDx/pull/8 introduced a problem when enabling/disabling the GPU backend.
It is fixed by switching to defines, rather than variables: when a backend is available, it has a definition and the definition is absent otherwise.