### PR TITLE
Add initial CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,6 @@ jobs:
             partition: defq
             gres: gpu:A4000
             cmake_flags: "-DTRIGDX_USE_MKL=1 -DTRIGDX_USE_GPU=1 -DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=86"
-          - name: NVIDIA GH200
-            partition: ghq
-            gres: gpu:GH200
-            cmake_flags: "-DTRIGDX_USE_GPU=1 -DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=90a -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc"
     env:
       DEVICE_NAME: ${{ matrix.name }}
       PARTITION_NAME: ${{ matrix.partition }}
@@ -55,9 +51,6 @@ jobs:
           - name: NVIDIA A4000
             partition: defq
             gres: gpu:A4000
-          - name: NVIDIA GH200
-            partition: ghq
-            gres: gpu:GH200
     env:
       DEVICE_NAME: ${{ matrix.name }}
       PARTITION_NAME: ${{ matrix.partition }}
@@ -83,9 +76,6 @@ jobs:
           - name: NVIDIA A4000
             partition: defq
             gres: gpu:A4000
-          - name: NVIDIA GH200
-            partition: ghq
-            gres: gpu:GH200
     env:
       DEVICE_NAME: ${{ matrix.name }}
       PARTITION_NAME: ${{ matrix.partition }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,7 @@ jobs:
             if [[ "$PARTITION_NAME" == defq ]]; then
               source /etc/profile.d/modules.sh
               module load spack/20250403
-              module load cuda
-              module load intel-oneapi-mkl
+              module load cuda intel-oneapi-mkl
               source /etc/profile
             fi
             cmake -S . -B build ${CMAKE_FLAGS}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
           partition: ${{ matrix.partition }}
           gres: ${{ matrix.gres }}
           commands: |
-            BUILD_DIR=$(mktemp -d -t build-XXXXXXXX)
             if [[ "$PARTITION_NAME" == defq ]]; then
               source /etc/profile.d/modules.sh
               module load spack/20250403
@@ -33,14 +32,13 @@ jobs:
             if [[ "$PARTITION_NAME" == defq ]]; then
               source /etc/profile
             fi
-            cmake -S . -B ${BUILD_DIR} ${CMAKE_FLAGS}
-            make -C ${BUILD_DIR} -j
-            tar czf "build-${{ matrix.name }}".tar.gz -C "${BUILD_DIR}"
+            cmake -S . -B build ${CMAKE_FLAGS}
+            make -C build -j
       - name: Upload build
         uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.name }}
-          path: build.tar.gz
+          path: build
 
   test:
     runs-on: [slurm]
@@ -63,9 +61,7 @@ jobs:
           partition: ${{ matrix.partition }}
           gres: ${{ matrix.gres }}
           commands: |
-            BUILD_DIR=$(mktemp -d -t build-XXXXXXXX)
-            tar xzf "build-${{ matrix.name }}".tar.gz -C "${BUILD_DIR}"
-            ctest --test-dir ${BUILD_DIR} --output-on-failure
+            ctest --test-dir build --output-on-failure
 
   benchmark:
     runs-on: [slurm]
@@ -88,6 +84,4 @@ jobs:
           partition: ${{ matrix.partition }}
           gres: ${{ matrix.gres }}
           commands: |
-            BUILD_DIR=$(mktemp -d -t build-XXXXXXXX)
-            tar xzf "build-${{ matrix.name }}".tar.gz -C "${BUILD_DIR}"
-            find ${BUILD_DIR}/benchmarks -type f -executable -exec {} \;
+            find build/benchmarks -type f -executable -exec {} \;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
           - name: NVIDIA GH200
             partition: ghq
             gres: gpu:GH200
-            cmake_flags: "-DTRIGDX_USE_GPU=1 -DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=90a"
+            cmake_flags: "-DTRIGDX_USE_GPU=1 -DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=90a -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc"
     env:
       DEVICE_NAME: ${{ matrix.name }}
       PARTITION_NAME: ${{ matrix.partition }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
 name: test
 on:
   push:
+
 jobs:
-  test-gpu:
+  build:
     runs-on: [slurm]
     strategy:
       matrix:
@@ -25,7 +26,6 @@ jobs:
         with:
           partition: ${{ matrix.partition }}
           gres: ${{ matrix.gres }}
-          time: "00:10:00"
           commands: |
             BUILD_DIR=$(mktemp -d -t build-XXXXXXXX)
             if [[ "$PARTITION_NAME" == defq ]]; then
@@ -39,5 +39,65 @@ jobs:
             fi
             cmake -S . -B ${BUILD_DIR} ${CMAKE_FLAGS}
             make -C ${BUILD_DIR} -j
+            tar czf "build-${{ matrix.name }}".tar.gz -C "${BUILD_DIR}"
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.name }}
+          path: build.tar.gz
+
+  test:
+    runs-on: [slurm]
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - name: NVIDIA A4000
+            partition: defq
+            gres: gpu:A4000
+          - name: NVIDIA GH200
+            partition: ghq
+            gres: gpu:GH200
+    env:
+      DEVICE_NAME: ${{ matrix.name }}
+      PARTITION_NAME: ${{ matrix.partition }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-${{ matrix.name }}
+      - uses: astron-rd/slurm-action@v1
+        with:
+          partition: ${{ matrix.partition }}
+          gres: ${{ matrix.gres }}
+          commands: |
+            BUILD_DIR=$(mktemp -d -t build-XXXXXXXX)
+            tar xzf "build-${{ matrix.name }}".tar.gz -C "${BUILD_DIR}"
             ctest --test-dir ${BUILD_DIR} --output-on-failure
+
+  benchmark:
+    runs-on: [slurm]
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - name: NVIDIA A4000
+            partition: defq
+            gres: gpu:A4000
+          - name: NVIDIA GH200
+            partition: ghq
+            gres: gpu:GH200
+    env:
+      DEVICE_NAME: ${{ matrix.name }}
+      PARTITION_NAME: ${{ matrix.partition }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-${{ matrix.name }}
+      - uses: astron-rd/slurm-action@v1
+        with:
+          partition: ${{ matrix.partition }}
+          gres: ${{ matrix.gres }}
+          commands: |
+            BUILD_DIR=$(mktemp -d -t build-XXXXXXXX)
+            tar xzf "build-${{ matrix.name }}".tar.gz -C "${BUILD_DIR}"
             find ${BUILD_DIR}/benchmarks -type f -executable -exec {} \;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: [slurm]
     strategy:
-      matrix:
+      matrix: &gpu-matrix
         include:
           - name: NVIDIA A4000
             partition: defq
@@ -41,11 +41,7 @@ jobs:
     runs-on: [slurm]
     needs: build
     strategy:
-      matrix:
-        include:
-          - name: NVIDIA A4000
-            partition: defq
-            gres: gpu:A4000
+      matrix: *gpu-matrix
     env:
       DEVICE_NAME: ${{ matrix.name }}
       PARTITION_NAME: ${{ matrix.partition }}
@@ -64,11 +60,7 @@ jobs:
     runs-on: [slurm]
     needs: build
     strategy:
-      matrix:
-        include:
-          - name: NVIDIA A4000
-            partition: defq
-            gres: gpu:A4000
+      matrix: *gpu-matrix
     env:
       DEVICE_NAME: ${{ matrix.name }}
       PARTITION_NAME: ${{ matrix.partition }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: test
+on:
+  push:
+jobs:
+  test-gpu:
+    runs-on: [slurm]
+    strategy:
+      matrix:
+        include:
+          - name: NVIDIA A4000
+            partition: defq
+            gres: gpu:A4000
+            cmake_flags: "-DTRIGDX_USE_MKL=1 -DTRIGDX_USE_GPU=1 -DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=86"
+          - name: NVIDIA GH200
+            partition: ghq
+            gres: gpu:GH200
+            cmake_flags: "-DTRIGDX_USE_GPU=1 -DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=90a"
+    env:
+      DEVICE_NAME: ${{ matrix.name }}
+      PARTITION_NAME: ${{ matrix.partition }}
+      CMAKE_FLAGS: ${{ matrix.cmake_flags }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astron-rd/slurm-action@v1
+        with:
+          partition: ${{ matrix.partition }}
+          gres: ${{ matrix.gres }}
+          time: "00:10:00"
+          commands: |
+            BUILD_DIR=$(mktemp -d -t build-XXXXXXXX)
+            if [[ "$PARTITION_NAME" == defq ]]; then
+              source /etc/profile.d/modules.sh
+              module load spack/20250403
+              module load cuda
+              module load intel-oneapi-mkl
+            fi
+            if [[ "$PARTITION_NAME" == defq ]]; then
+              source /etc/profile
+            fi
+            cmake -S . -B ${BUILD_DIR} ${CMAKE_FLAGS}
+            make -C ${BUILD_DIR} -j
+            ctest --test-dir ${BUILD_DIR} --output-on-failure
+            find ${BUILD_DIR}/benchmarks -type f -executable -exec {} \;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,6 @@ jobs:
               module load spack/20250403
               module load cuda
               module load intel-oneapi-mkl
-            fi
-            if [[ "$PARTITION_NAME" == defq ]]; then
               source /etc/profile
             fi
             cmake -S . -B build ${CMAKE_FLAGS}


### PR DESCRIPTION
This addresses https://github.com/astron-rd/TrigDx/issues/15, an initial GitHub workflow is added that compiles the code on an x86 and an aarch64 system and tries to run the tests and benchmarks.

The build on aarch64 is currently broken, but this is fixed in https://github.com/astron-rd/TrigDx/pull/13. For now this doesn't cause the CI to fail, we can change this later (e.g. by adding `&&` between the stages) once https://github.com/astron-rd/TrigDx/pull/13 is merged.