### PR TITLE
Add AVX checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(TRIGDX_BUILD_TESTS "Build tests" ON)
 option(TRIGDX_BUILD_BENCHMARKS "Build tests" ON)
 option(TRIGDX_BUILD_PYTHON "Build Python interface" ON)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/trigdx_config.hpp.in
   ${CMAKE_CURRENT_BINARY_DIR}/include/trigdx/trigdx_config.hpp @ONLY)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -13,8 +13,11 @@ target_link_libraries(benchmark_reference PRIVATE trigdx benchmark::benchmark)
 add_executable(benchmark_lookup benchmark_lookup.cpp)
 target_link_libraries(benchmark_lookup PRIVATE trigdx benchmark::benchmark)
 
-add_executable(benchmark_lookup_avx benchmark_lookup_avx.cpp)
-target_link_libraries(benchmark_lookup_avx PRIVATE trigdx benchmark::benchmark)
+if(HAVE_AVX)
+  add_executable(benchmark_lookup_avx benchmark_lookup_avx.cpp)
+  target_link_libraries(benchmark_lookup_avx PRIVATE trigdx
+                                                     benchmark::benchmark)
+endif()
 
 if(TRIGDX_USE_MKL)
   add_executable(benchmark_mkl benchmark_mkl.cpp)

--- a/cmake/FindAVX.cmake
+++ b/cmake/FindAVX.cmake
@@ -26,9 +26,10 @@ int main() {
 "
   HAVE_AVX)
 
-# AVX2 check
-check_cxx_source_runs(
-  "
+if(HAVE_AVX)
+  # AVX2 check
+  check_cxx_source_runs(
+    "
 #include <immintrin.h>
 int main() {
     __m256i a = _mm256_set1_epi32(-1);
@@ -37,4 +38,5 @@ int main() {
     return 0;
 }
 "
-  HAVE_AVX2)
+    HAVE_AVX2)
+endif()

--- a/cmake/FindAVX.cmake
+++ b/cmake/FindAVX.cmake
@@ -13,8 +13,4 @@ int main() {
 }"
   HAVE_AVX)
 
-if(HAVE_AVX)
-  message(STATUS "AVX instruction set is supported")
-else()
-  message(STATUS "No AVX support found.")
-endif()
+message(STATUS "AVX support: " ${HAVE_AVX})

--- a/cmake/FindAVX.cmake
+++ b/cmake/FindAVX.cmake
@@ -1,0 +1,20 @@
+include(CheckCXXSourceRuns)
+
+set(CMAKE_REQUIRED_FLAGS "-mavx") # for GCC/Clang; use /arch:AVX for MSVC
+
+check_cxx_source_runs(
+  "
+#include <immintrin.h>
+int main() {
+  __m256 a = _mm256_set_ps(-1.0f,2.0f,-3.0f,4.0f,-1.0f,2.0f,-3.0f,4.0f);
+  __m256 b = _mm256_set_ps(1.0f,2.0f,3.0f,4.0f,1.0f,2.0f,3.0f,4.0f);
+  __m256 result = _mm256_add_ps(a,b);
+  return 0;
+}"
+  HAVE_AVX)
+
+if(HAVE_AVX)
+  message(STATUS "AVX instruction set is supported")
+else()
+  message(STATUS "No AVX support found.")
+endif()

--- a/cmake/FindAVX.cmake
+++ b/cmake/FindAVX.cmake
@@ -1,6 +1,12 @@
 include(CheckCXXSourceRuns)
 
-set(CMAKE_REQUIRED_FLAGS "-mavx") # for GCC/Clang; use /arch:AVX for MSVC
+set(SUPPORTED_COMPILERS Clang;GNU;Intel)
+
+if(CMAKE_CXX_COMPILER_ID IN_LIST SUPPORTED_COMPILERS)
+  set(CMAKE_REQUIRED_FLAGS "-mavx") # for GCC/Clang; use /arch:AVX for MSVC
+else()
+  message(FATAL_ERROR "Compiler : " ${CMAKE_CXX_COMPILER_ID} " not supported")
+endif()
 
 check_cxx_source_runs(
   "
@@ -13,4 +19,8 @@ int main() {
 }"
   HAVE_AVX)
 
-message(STATUS "AVX support: " ${HAVE_AVX})
+if(HAVE_AVX)
+  message(STATUS "AVX support: true")
+else()
+  message(STATUS "AVX support: false")
+endif()

--- a/cmake/FindAVX.cmake
+++ b/cmake/FindAVX.cmake
@@ -1,26 +1,40 @@
 include(CheckCXXSourceRuns)
 
-set(SUPPORTED_COMPILERS Clang;GNU;Intel)
+set(SUPPORTED_COMPILERS Clang;GNU;Intel;IntelLLVM)
 
 if(CMAKE_CXX_COMPILER_ID IN_LIST SUPPORTED_COMPILERS)
-  set(CMAKE_REQUIRED_FLAGS "-mavx") # for GCC/Clang; use /arch:AVX for MSVC
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    set(CMAKE_REQUIRED_FLAGS "-xHost") # ICC
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+    set(CMAKE_REQUIRED_FLAGS "-march=native") # ICX
+  else()
+    set(CMAKE_REQUIRED_FLAGS "-march=native") # GCC/Clang
+  endif()
 else()
-  message(FATAL_ERROR "Compiler : " ${CMAKE_CXX_COMPILER_ID} " not supported")
+  message(FATAL_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}.")
 endif()
 
+# AVX check
 check_cxx_source_runs(
   "
 #include <immintrin.h>
 int main() {
-  __m256 a = _mm256_set_ps(-1.0f,2.0f,-3.0f,4.0f,-1.0f,2.0f,-3.0f,4.0f);
-  __m256 b = _mm256_set_ps(1.0f,2.0f,3.0f,4.0f,1.0f,2.0f,3.0f,4.0f);
-  __m256 result = _mm256_add_ps(a,b);
-  return 0;
-}"
+    __m256 a = _mm256_setzero_ps(); // AVX
+    (void) a;
+    return 0;
+}
+"
   HAVE_AVX)
 
-if(HAVE_AVX)
-  message(STATUS "AVX support: true")
-else()
-  message(STATUS "AVX support: false")
-endif()
+# AVX2 check
+check_cxx_source_runs(
+  "
+#include <immintrin.h>
+int main() {
+    __m256i a = _mm256_set1_epi32(-1);
+    __m256i b = _mm256_abs_epi32(a); // AVX2
+    (void) b;
+    return 0;
+}
+"
+  HAVE_AVX2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(TRIGDX_USE_GPU)
 endif()
 
 if(TRIGDX_USE_XSIMD)
-  find_package(xsimd QUIET)
+  find_package(xsimd 13.0.0 QUIET VERSION)
   if(NOT TARGET xsimd)
     FetchContent_Declare(
       xsimd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,14 @@
 include(FetchContent)
-
-add_library(trigdx reference.cpp lookup.cpp lookup_avx.cpp)
+include(FindAVX)
+add_library(trigdx reference.cpp lookup.cpp)
 
 target_include_directories(trigdx PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 target_compile_options(trigdx PRIVATE -O3 -march=native)
+
+if(HAVE_AVX)
+  target_sources(trigdx PRIVATE lookup_avx.cpp)
+endif()
 
 if(TRIGDX_USE_MKL)
   find_package(MKL REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ if(TRIGDX_USE_GPU)
 endif()
 
 if(TRIGDX_USE_XSIMD)
+  # Requires XSIMD > 13 for architecture independent dispatching
   find_package(xsimd 13 QUIET)
   if(NOT TARGET xsimd)
     FetchContent_Declare(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,6 @@ add_library(trigdx reference.cpp lookup.cpp)
 
 target_include_directories(trigdx PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
-target_compile_options(trigdx PRIVATE -O3 -march=native)
-
 if(HAVE_AVX)
   target_sources(trigdx PRIVATE lookup_avx.cpp)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ if(TRIGDX_USE_GPU)
 endif()
 
 if(TRIGDX_USE_XSIMD)
-  find_package(xsimd 13.0.0 QUIET VERSION)
+  find_package(xsimd 13 QUIET)
   if(NOT TARGET xsimd)
     FetchContent_Declare(
       xsimd

--- a/src/lookup_avx.cpp
+++ b/src/lookup_avx.cpp
@@ -1,9 +1,8 @@
 #include <algorithm>
 #include <cmath>
-#include <vector>
-#if defined(__AVX__)
 #include <immintrin.h>
-#endif
+#include <vector>
+
 #include "trigdx/lookup_avx.hpp"
 
 template <std::size_t NR_SAMPLES> struct LookupAVXBackend<NR_SAMPLES>::Impl {

--- a/src/lookup_avx.cpp
+++ b/src/lookup_avx.cpp
@@ -1,7 +1,8 @@
 #include <algorithm>
 #include <cmath>
-#include <immintrin.h>
 #include <vector>
+
+#include <immintrin.h>
 
 #include "trigdx/lookup_avx.hpp"
 
@@ -159,7 +160,6 @@ template <std::size_t NR_SAMPLES> struct LookupAVXBackend<NR_SAMPLES>::Impl {
     for (std::size_t i = 0; i < n; ++i) {
       std::size_t idx = static_cast<std::size_t>(x[i] * SCALE) & MASK;
       std::size_t idx_cos = (idx + NR_SAMPLES / 4) & MASK;
-
       c[i] = lookup[idx_cos];
     }
 #endif

--- a/src/lookup_avx.cpp
+++ b/src/lookup_avx.cpp
@@ -1,9 +1,9 @@
 #include <algorithm>
 #include <cmath>
 #include <vector>
-
+#if defined(__AVX__)
 #include <immintrin.h>
-
+#endif
 #include "trigdx/lookup_avx.hpp"
 
 template <std::size_t NR_SAMPLES> struct LookupAVXBackend<NR_SAMPLES>::Impl {
@@ -160,7 +160,7 @@ template <std::size_t NR_SAMPLES> struct LookupAVXBackend<NR_SAMPLES>::Impl {
     for (std::size_t i = 0; i < n; ++i) {
       std::size_t idx = static_cast<std::size_t>(x[i] * SCALE) & MASK;
       std::size_t idx_cos = (idx + NR_SAMPLES / 4) & MASK;
-      s[i] = lookup[idx];
+
       c[i] = lookup[idx_cos];
     }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,9 +10,11 @@ target_link_libraries(test_lookup PRIVATE trigdx Catch2::Catch2WithMain)
 add_test(NAME test_lookup COMMAND test_lookup)
 
 # LookupAVX backend test
-add_executable(test_lookup_avx test_lookup_avx.cpp)
-target_link_libraries(test_lookup_avx PRIVATE trigdx Catch2::Catch2WithMain)
-add_test(NAME test_lookup_avx COMMAND test_lookup_avx)
+if(HAVE_AVX)
+  add_executable(test_lookup_avx test_lookup_avx.cpp)
+  target_link_libraries(test_lookup_avx PRIVATE trigdx Catch2::Catch2WithMain)
+  add_test(NAME test_lookup_avx COMMAND test_lookup_avx)
+endif()
 
 # MKL backend test
 if(TRIGDX_USE_MKL)


### PR DESCRIPTION
This is an extended version of https://github.com/astron-rd/TrigDx/pull/13, rebased onto the latest `main` branch.
The AVX detection is extended to include AVX2 and the `LookupAVX` test and benchmark are now only build when AVX support is detected.