### PR TITLE
Add Taylor expansion to LookupXSIMD

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,15 @@
+name: linting
+on:
+  push:
+jobs:
+  format:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y clang-format-14 cmake-format pre-commit
+      - run: pre-commit run -a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.name }}
+          path: build
       - uses: astron-rd/slurm-action@v1.1
         with:
           partition: ${{ matrix.partition }}
@@ -75,6 +76,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.name }}
+          path: build
       - uses: astron-rd/slurm-action@v1.1
         with:
           partition: ${{ matrix.partition }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       ENVIRONMENT_MODULES: ${{ matrix.environment_modules }}
     steps:
       - uses: actions/checkout@v4
-      - uses: astron-rd/slurm-action@v1
+      - uses: astron-rd/slurm-action@v1.1
         with:
           partition: ${{ matrix.partition }}
           gres: ${{ matrix.gres }}
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.name }}
-      - uses: astron-rd/slurm-action@v1
+      - uses: astron-rd/slurm-action@v1.1
         with:
           partition: ${{ matrix.partition }}
           gres: ${{ matrix.gres }}
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.name }}
-      - uses: astron-rd/slurm-action@v1
+      - uses: astron-rd/slurm-action@v1.1
         with:
           partition: ${{ matrix.partition }}
           gres: ${{ matrix.gres }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ jobs:
             gres: gpu:A4000
             cmake_flags: "-DTRIGDX_USE_MKL=1 -DTRIGDX_USE_GPU=1 -DTRIGDX_USE_MKL=1-DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=86"
             environment_modules: "spack/20250403 intel-oneapi-compilers intel-oneapi-mkl cuda python"
+          - name: GNU, NVIDIA GH200
+            partition: ghq
+            gres: gpu:GH200
+            cmake_flags: "-DTRIGDX_USE_GPU=1 -DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=90a -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc"
     env:
       DEVICE_NAME: ${{ matrix.name }}
       PARTITION_NAME: ${{ matrix.partition }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
             module load ${ENVIRONMENT_MODULES}
             cmake -S . -B build ${CMAKE_FLAGS}
             make -C build -j
+            cp -r build "$GITHUB_WORKSPACE/"
       - name: Upload build
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,23 @@ jobs:
   build:
     runs-on: [slurm]
     strategy:
-      matrix: &gpu-matrix
+      matrix: &matrix
         include:
-          - name: NVIDIA A4000
+          - name: GNU, NVIDIA A4000
             partition: defq
             gres: gpu:A4000
-            cmake_flags: "-DTRIGDX_USE_MKL=1 -DTRIGDX_USE_GPU=1 -DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=86"
+            cmake_flags: "-DTRIGDX_USE_MKL=1 -DTRIGDX_USE_GPU=1 -DTRIGDX_USE_MKL=1 -DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=86"
+            environment_modules: "spack/20250403 intel-oneapi-mkl cuda python"
+          - name: Intel, NVIDIA A4000
+            partition: defq
+            gres: gpu:A4000
+            cmake_flags: "-DTRIGDX_USE_MKL=1 -DTRIGDX_USE_GPU=1 -DTRIGDX_USE_MKL=1-DTRIGDX_USE_XSIMD=1 -DCMAKE_CUDA_ARCHITECTURES=86"
+            environment_modules: "spack/20250403 intel-oneapi-compilers intel-oneapi-mkl cuda python"
     env:
       DEVICE_NAME: ${{ matrix.name }}
       PARTITION_NAME: ${{ matrix.partition }}
       CMAKE_FLAGS: ${{ matrix.cmake_flags }}
+      ENVIRONMENT_MODULES: ${{ matrix.environment_modules }}
     steps:
       - uses: actions/checkout@v4
       - uses: astron-rd/slurm-action@v1
@@ -23,11 +30,7 @@ jobs:
           partition: ${{ matrix.partition }}
           gres: ${{ matrix.gres }}
           commands: |
-            if [[ "$PARTITION_NAME" == defq ]]; then
-              module load spack/20250403
-              module load cuda intel-oneapi-mkl python
-              source /etc/profile
-            fi
+            module load ${ENVIRONMENT_MODULES}
             cmake -S . -B build ${CMAKE_FLAGS}
             make -C build -j
       - name: Upload build
@@ -40,7 +43,7 @@ jobs:
     runs-on: [slurm]
     needs: build
     strategy:
-      matrix: *gpu-matrix
+      matrix: *matrix
     env:
       DEVICE_NAME: ${{ matrix.name }}
       PARTITION_NAME: ${{ matrix.partition }}
@@ -59,7 +62,7 @@ jobs:
     runs-on: [slurm]
     needs: build
     strategy:
-      matrix: *gpu-matrix
+      matrix: *matrix
     env:
       DEVICE_NAME: ${{ matrix.name }}
       PARTITION_NAME: ${{ matrix.partition }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,8 @@ jobs:
           gres: ${{ matrix.gres }}
           commands: |
             if [[ "$PARTITION_NAME" == defq ]]; then
-              source /etc/profile.d/modules.sh
               module load spack/20250403
-              module load cuda intel-oneapi-mkl
+              module load cuda intel-oneapi-mkl python
               source /etc/profile
             fi
             cmake -S . -B build ${CMAKE_FLAGS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(TRIGDX_BUILD_TESTS "Build tests" ON)
 option(TRIGDX_BUILD_BENCHMARKS "Build tests" ON)
 option(TRIGDX_BUILD_PYTHON "Build Python interface" ON)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/trigdx_config.hpp.in
   ${CMAKE_CURRENT_BINARY_DIR}/include/trigdx/trigdx_config.hpp @ONLY)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -13,8 +13,11 @@ target_link_libraries(benchmark_reference PRIVATE trigdx benchmark::benchmark)
 add_executable(benchmark_lookup benchmark_lookup.cpp)
 target_link_libraries(benchmark_lookup PRIVATE trigdx benchmark::benchmark)
 
-add_executable(benchmark_lookup_avx benchmark_lookup_avx.cpp)
-target_link_libraries(benchmark_lookup_avx PRIVATE trigdx benchmark::benchmark)
+if(HAVE_AVX)
+  add_executable(benchmark_lookup_avx benchmark_lookup_avx.cpp)
+  target_link_libraries(benchmark_lookup_avx PRIVATE trigdx
+                                                     benchmark::benchmark)
+endif()
 
 if(TRIGDX_USE_MKL)
   add_executable(benchmark_mkl benchmark_mkl.cpp)

--- a/cmake/FindAVX.cmake
+++ b/cmake/FindAVX.cmake
@@ -26,9 +26,10 @@ int main() {
 "
   HAVE_AVX)
 
-# AVX2 check
-check_cxx_source_runs(
-  "
+if(HAVE_AVX)
+  # AVX2 check
+  check_cxx_source_runs(
+    "
 #include <immintrin.h>
 int main() {
     __m256i a = _mm256_set1_epi32(-1);
@@ -37,4 +38,5 @@ int main() {
     return 0;
 }
 "
-  HAVE_AVX2)
+    HAVE_AVX2)
+endif()

--- a/cmake/FindAVX.cmake
+++ b/cmake/FindAVX.cmake
@@ -13,8 +13,4 @@ int main() {
 }"
   HAVE_AVX)
 
-if(HAVE_AVX)
-  message(STATUS "AVX instruction set is supported")
-else()
-  message(STATUS "No AVX support found.")
-endif()
+message(STATUS "AVX support: " ${HAVE_AVX})

--- a/cmake/FindAVX.cmake
+++ b/cmake/FindAVX.cmake
@@ -1,0 +1,20 @@
+include(CheckCXXSourceRuns)
+
+set(CMAKE_REQUIRED_FLAGS "-mavx") # for GCC/Clang; use /arch:AVX for MSVC
+
+check_cxx_source_runs(
+  "
+#include <immintrin.h>
+int main() {
+  __m256 a = _mm256_set_ps(-1.0f,2.0f,-3.0f,4.0f,-1.0f,2.0f,-3.0f,4.0f);
+  __m256 b = _mm256_set_ps(1.0f,2.0f,3.0f,4.0f,1.0f,2.0f,3.0f,4.0f);
+  __m256 result = _mm256_add_ps(a,b);
+  return 0;
+}"
+  HAVE_AVX)
+
+if(HAVE_AVX)
+  message(STATUS "AVX instruction set is supported")
+else()
+  message(STATUS "No AVX support found.")
+endif()

--- a/cmake/FindAVX.cmake
+++ b/cmake/FindAVX.cmake
@@ -1,6 +1,12 @@
 include(CheckCXXSourceRuns)
 
-set(CMAKE_REQUIRED_FLAGS "-mavx") # for GCC/Clang; use /arch:AVX for MSVC
+set(SUPPORTED_COMPILERS Clang;GNU;Intel)
+
+if(CMAKE_CXX_COMPILER_ID IN_LIST SUPPORTED_COMPILERS)
+  set(CMAKE_REQUIRED_FLAGS "-mavx") # for GCC/Clang; use /arch:AVX for MSVC
+else()
+  message(FATAL_ERROR "Compiler : " ${CMAKE_CXX_COMPILER_ID} " not supported")
+endif()
 
 check_cxx_source_runs(
   "
@@ -13,4 +19,8 @@ int main() {
 }"
   HAVE_AVX)
 
-message(STATUS "AVX support: " ${HAVE_AVX})
+if(HAVE_AVX)
+  message(STATUS "AVX support: true")
+else()
+  message(STATUS "AVX support: false")
+endif()

--- a/cmake/FindAVX.cmake
+++ b/cmake/FindAVX.cmake
@@ -1,26 +1,40 @@
 include(CheckCXXSourceRuns)
 
-set(SUPPORTED_COMPILERS Clang;GNU;Intel)
+set(SUPPORTED_COMPILERS Clang;GNU;Intel;IntelLLVM)
 
 if(CMAKE_CXX_COMPILER_ID IN_LIST SUPPORTED_COMPILERS)
-  set(CMAKE_REQUIRED_FLAGS "-mavx") # for GCC/Clang; use /arch:AVX for MSVC
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    set(CMAKE_REQUIRED_FLAGS "-xHost") # ICC
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+    set(CMAKE_REQUIRED_FLAGS "-march=native") # ICX
+  else()
+    set(CMAKE_REQUIRED_FLAGS "-march=native") # GCC/Clang
+  endif()
 else()
-  message(FATAL_ERROR "Compiler : " ${CMAKE_CXX_COMPILER_ID} " not supported")
+  message(FATAL_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}.")
 endif()
 
+# AVX check
 check_cxx_source_runs(
   "
 #include <immintrin.h>
 int main() {
-  __m256 a = _mm256_set_ps(-1.0f,2.0f,-3.0f,4.0f,-1.0f,2.0f,-3.0f,4.0f);
-  __m256 b = _mm256_set_ps(1.0f,2.0f,3.0f,4.0f,1.0f,2.0f,3.0f,4.0f);
-  __m256 result = _mm256_add_ps(a,b);
-  return 0;
-}"
+    __m256 a = _mm256_setzero_ps(); // AVX
+    (void) a;
+    return 0;
+}
+"
   HAVE_AVX)
 
-if(HAVE_AVX)
-  message(STATUS "AVX support: true")
-else()
-  message(STATUS "AVX support: false")
-endif()
+# AVX2 check
+check_cxx_source_runs(
+  "
+#include <immintrin.h>
+int main() {
+    __m256i a = _mm256_set1_epi32(-1);
+    __m256i b = _mm256_abs_epi32(a); // AVX2
+    (void) b;
+    return 0;
+}
+"
+  HAVE_AVX2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(TRIGDX_USE_GPU)
 endif()
 
 if(TRIGDX_USE_XSIMD)
-  find_package(xsimd QUIET)
+  find_package(xsimd 13.0.0 QUIET VERSION)
   if(NOT TARGET xsimd)
     FetchContent_Declare(
       xsimd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,14 @@
 include(FetchContent)
-
-add_library(trigdx reference.cpp lookup.cpp lookup_avx.cpp)
+include(FindAVX)
+add_library(trigdx reference.cpp lookup.cpp)
 
 target_include_directories(trigdx PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 target_compile_options(trigdx PRIVATE -O3 -march=native)
+
+if(HAVE_AVX)
+  target_sources(trigdx PRIVATE lookup_avx.cpp)
+endif()
 
 if(TRIGDX_USE_MKL)
   find_package(MKL REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ if(TRIGDX_USE_GPU)
 endif()
 
 if(TRIGDX_USE_XSIMD)
+  # Requires XSIMD > 13 for architecture independent dispatching
   find_package(xsimd 13 QUIET)
   if(NOT TARGET xsimd)
     FetchContent_Declare(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,6 @@ add_library(trigdx reference.cpp lookup.cpp)
 
 target_include_directories(trigdx PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
-target_compile_options(trigdx PRIVATE -O3 -march=native)
-
 if(HAVE_AVX)
   target_sources(trigdx PRIVATE lookup_avx.cpp)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ if(TRIGDX_USE_GPU)
 endif()
 
 if(TRIGDX_USE_XSIMD)
-  find_package(xsimd 13.0.0 QUIET VERSION)
+  find_package(xsimd 13 QUIET)
   if(NOT TARGET xsimd)
     FetchContent_Declare(
       xsimd

--- a/src/lookup_avx.cpp
+++ b/src/lookup_avx.cpp
@@ -1,9 +1,8 @@
 #include <algorithm>
 #include <cmath>
-#include <vector>
-#if defined(__AVX__)
 #include <immintrin.h>
-#endif
+#include <vector>
+
 #include "trigdx/lookup_avx.hpp"
 
 template <std::size_t NR_SAMPLES> struct LookupAVXBackend<NR_SAMPLES>::Impl {

--- a/src/lookup_avx.cpp
+++ b/src/lookup_avx.cpp
@@ -1,9 +1,9 @@
 #include <algorithm>
 #include <cmath>
 #include <vector>
-
+#if defined(__AVX__)
 #include <immintrin.h>
-
+#endif
 #include "trigdx/lookup_avx.hpp"
 
 template <std::size_t NR_SAMPLES> struct LookupAVXBackend<NR_SAMPLES>::Impl {
@@ -160,7 +160,7 @@ template <std::size_t NR_SAMPLES> struct LookupAVXBackend<NR_SAMPLES>::Impl {
     for (std::size_t i = 0; i < n; ++i) {
       std::size_t idx = static_cast<std::size_t>(x[i] * SCALE) & MASK;
       std::size_t idx_cos = (idx + NR_SAMPLES / 4) & MASK;
-      s[i] = lookup[idx];
+
       c[i] = lookup[idx_cos];
     }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,9 +10,11 @@ target_link_libraries(test_lookup PRIVATE trigdx Catch2::Catch2WithMain)
 add_test(NAME test_lookup COMMAND test_lookup)
 
 # LookupAVX backend test
-add_executable(test_lookup_avx test_lookup_avx.cpp)
-target_link_libraries(test_lookup_avx PRIVATE trigdx Catch2::Catch2WithMain)
-add_test(NAME test_lookup_avx COMMAND test_lookup_avx)
+if(HAVE_AVX)
+  add_executable(test_lookup_avx test_lookup_avx.cpp)
+  target_link_libraries(test_lookup_avx PRIVATE trigdx Catch2::Catch2WithMain)
+  add_test(NAME test_lookup_avx COMMAND test_lookup_avx)
+endif()
 
 # MKL backend test
 if(TRIGDX_USE_MKL)


### PR DESCRIPTION
This is a rebased and slightly modified version of https://github.com/astron-rd/TrigDx/pull/12.

Original description:
> This is the same xsimd lookup with a Taylor expansion.
> We get now a precision of 1.e-6.

Which is indeed the case for sufficiently large lookup table sizes:
<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/c5d44268-8d49-4173-87d7-83031938dc0d" />

For later reference, some more plots with smaller lookup table sizes:
<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/6f3beecb-24ab-45b0-bc28-5c25c195f753" />
<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/b074ed63-431e-41b7-8902-144833dd7b29" />
