### PR TITLE
Only fetch pybind11 when target not available

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,8 +1,10 @@
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY https://github.com/pybind/pybind11.git
-  GIT_TAG v3.0.0)
-FetchContent_MakeAvailable(pybind11)
+if(NOT TARGET pybind11)
+  FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG v3.0.0)
+  FetchContent_MakeAvailable(pybind11)
+endif()
 
 pybind11_add_module(pytrigdx bindings.cpp)
 target_link_libraries(pytrigdx PRIVATE trigdx)


### PR DESCRIPTION
If a pybind11 CMake target is already defined in the project, we should avoid re-declaring it. Overwriting an existing target can lead to runtime errors such as:
```
Traceback (most recent call last): File "<stdin>", line 1, in <module> import pybind11_tests ModuleNotFoundError: No module named 'pybind11_tests'
```