### PR TITLE
Fixed broken pybind11 target check

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,3 @@
-# Check if pybind11 is already available, otherwise fetch it
 find_package(pybind11 CONFIG QUIET)
 
 if(NOT pybind11_FOUND)


### PR DESCRIPTION
This MR is related to #25 and fixes an issue whether CMake would still override the user's `pybind11`, even though it is already available.