### PR TITLE
Remove unused constant in lookup_avx.cpp

### DIFF
--- a/src/lookup_avx.cpp
+++ b/src/lookup_avx.cpp
@@ -89,7 +89,6 @@ template <std::size_t NR_SAMPLES> struct LookupAVXBackend<NR_SAMPLES>::Impl {
     constexpr std::size_t VL = 8; // AVX processes 8 floats
     const __m256 scale = _mm256_set1_ps(SCALE);
     const __m256i mask = _mm256_set1_epi32(MASK);
-    const __m256i quarter_pi = _mm256_set1_epi32(NR_SAMPLES / 4);
 
     std::size_t i = 0;
     for (; i + VL <= n; i += VL) {


### PR DESCRIPTION
This pull request makes a minor cleanup to the `LookupAVXBackend` implementation by removing an unused variable. No functional changes are introduced.

- Code cleanup:
  * Removed the unused `quarter_pi` variable from the `Impl` struct in `lookup_avx.cpp` to reduce clutter and improve maintainability.