### PR TITLE
Add XTL requirement to TrigDX

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,17 @@ if(TRIGDX_USE_XSIMD)
       GIT_TAG 13.2.0)
     FetchContent_MakeAvailable(xsimd)
   endif()
+
+  # Requires xtl > 0.7.x for XSIMD > 13
+  find_package(xtl 0.7.7 QUIET)
+  if(NOT TARGET xtl)
+    FetchContent_Declare(
+      xtl
+      GIT_REPOSITORY https://github.com/xtensor-stack/xtl.git
+      GIT_TAG 0.7.7)
+    FetchContent_MakeAvailable(xtl)
+  endif()
+
   target_sources(trigdx PRIVATE lookup_xsimd.cpp)
   target_link_libraries(trigdx PRIVATE xsimd)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,7 @@ if(TRIGDX_USE_XSIMD)
   endif()
 
   target_sources(trigdx PRIVATE lookup_xsimd.cpp)
-  target_link_libraries(trigdx PRIVATE xsimd)
+  target_link_libraries(trigdx PRIVATE xsimd xtl)
 endif()
 
 target_include_directories(


### PR DESCRIPTION
When building without having installed XTL linking becomes an issue for dependent projects